### PR TITLE
extract description two step

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,9 +85,10 @@ var metaScraper = function metaScraper(url) {
       returnData.title = returnData.og && returnData.og.title ? returnData.og.title : returnData.twitter && returnData.twitter.title ? returnData.twitter.title : returnData.pageTitle;
 
       // Add description
-      var description = metaArray.filter(function (item) {
+      var descriptions = metaArray.filter(function (item) {
         return item.name && item.name === 'description';
-      })[0].content || false;
+      })
+      var description = descriptions.length ? descriptions[0].content : false;
       returnData.description = returnData.og && returnData.og.description ? returnData.og.description : returnData.twitter && returnData.twitter.description ? returnData.twitter.description : description;
 
       // Add image


### PR DESCRIPTION
the filter function for descriptions assumed that the metaArray
would contain at least one description, which is not always the case.
pull description in two steps to guard against sites missing
descriptions in meta elements.

example: http://hosted.ap.org/dynamic/stories/A/APFN_US_TRUMP_IMMIGRATION_AROL-?SITE=AP